### PR TITLE
Remove networks using default and add mysql env.

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,24 +8,11 @@ services:
     command: uvicorn app:app --host 0.0.0.0 --port 8000
     ports:
       - "8000:8000"
-    networks:
-      - fastapi_network
 
   db:
     image: mysql
     container_name: docker-mysql
     ports:
       - "3306:3306"
-    expose:
-      - "3306"
-    networks:
-      - fastapi_network
-
-networks:
-  default:
-    external:
-      name: bridge
-  fastapi_network:
-    name: fastapi_network
-    driver: bridge
-    external: true
+    environment:
+      - MYSQL_ALLOW_EMPTY_PASSWORD=yes # https://hub.docker.com/_/mysql


### PR DESCRIPTION
> By default Compose sets up a single network for your app. Each container for a service joins the default network and is both reachable by other containers on that network, and discoverable by them at a hostname identical to the container name.

ref: https://docs.docker.com/compose/networking/

**ERROR** please read mysql docker hub description
<img width="960" alt="b2" src="https://user-images.githubusercontent.com/10204176/128618443-9199561d-54f6-4aa5-940d-9e27589867be.png">
